### PR TITLE
fix: format the code & remove unused dependency `structopt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ name = "emtr"
 path = "src/cli/main.rs"
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-structopt = "0.3"
 colored = "2.0"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ sha = "0.10"
 [dependencies.bin]
 petgraph = "0.6"
 hex = "0.4"
-structopt = "0.3"
 colored = "2.0"
 ```
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,6 +2,7 @@
 //!
 //! Command line interface for the Ethereum Merkle tree library.
 
+use clap::Parser;
 use colored::*;
 use eth_merkle_tree::tree::MerkleTree;
 use eth_merkle_tree::utils::keccak::keccak256;
@@ -10,7 +11,6 @@ use std::error::Error;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
-use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(name = "eth-merkle-tree-rs", about = "Ethereum Merkle Tree Tool")]


### PR DESCRIPTION
@guvenemirhan Thanks for switching to `clap`!
I just reformatted the code and removed the dependency `structopt` so that CI is green.